### PR TITLE
Clean up python syntax and python requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "spyrrow"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/spyrrow.pyi
+++ b/spyrrow.pyi
@@ -1,6 +1,8 @@
-type Point = tuple[float,float]
+from typing import TypeAlias
 
-type ItemId = int
+Point: TypeAlias = tuple[float,float]
+
+ItemId: TypeAlias = int
 
 class Item:
     demand:int


### PR DESCRIPTION
- `type Point = tuple[float, float]` is python 3.12+ https://docs.python.org/3/whatsnew/3.12.html#whatsnew312-pep695 -> downgrade to use `TypeAlias` syntax (this still works in < 3.12, but causes type checkers such as mypy to crash due to syntax error)
- require >= 3.10 as 3.8 / 3.9 are EOL or will be in a few months. 3.10 is the lowest version of python I tested, but can go below