### PR TITLE
Ensure Github detects Python as primary language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
-*.py linguist-language=Python
+# Treat all Rust files as vendored (excluded from language stats)
+*.rs linguist-vendored
+
+# Ensure Python files are counted
+*.py linguist-detectable=true


### PR DESCRIPTION
Currently the repo contains slightly more lines of Rust compared to Python.
Causing GitHub to misclassify `spyrrow` as a Rust repository.

This PR adds a `.gitattributes` file to instruct linguist to ignore Rust lines when determining the language.
Should increase the repo's reach.

Before:
<img width="518" height="159" alt="image" src="https://github.com/user-attachments/assets/455b4b64-a124-4deb-96ef-78e65c865cf5" />

After:
<img width="514" height="146" alt="image" src="https://github.com/user-attachments/assets/e8e78c19-b552-4996-bad3-c18a5dcff51f" />
 