### PR TITLE
Add optional progress reporting via ProgressQueue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,29 +34,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -84,15 +84,24 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -125,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.50"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -135,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.50"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -147,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -159,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -211,35 +220,41 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctrlc"
-version = "3.5.0"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
- "dispatch",
+ "dispatch2",
  "nix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
 
 [[package]]
 name = "dtoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "either"
@@ -310,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a4dcd69d35b2c87a7c83bce9af69fd65c9d68d3833a0ded568983928f3fc99"
+checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
 dependencies = [
  "approx",
  "num-traits",
@@ -322,18 +337,18 @@ dependencies = [
 
 [[package]]
 name = "geographiclib-rs"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f611040a2bb37eaa29a78a128d1e92a378a03e0b6e66ae27398d42b1ba9a7841"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -414,15 +429,18 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -435,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jagua-rs"
@@ -465,24 +483,24 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
- "windows-sys 0.59.0",
+ "serde_core",
+ "windows-sys",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -491,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -506,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -522,21 +540,21 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -549,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matrixmultiply"
@@ -565,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -595,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -654,6 +672,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,9 +694,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"
@@ -676,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -701,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -771,18 +804,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -870,12 +903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,22 +946,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "slotmap"
-version = "1.0.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]
@@ -985,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "spyrrow"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "jagua-rs",
  "num_cpus",
@@ -1016,9 +1043,9 @@ checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1033,9 +1060,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "test-case"
@@ -1072,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -1102,11 +1129,11 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1115,14 +1142,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1132,24 +1159,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1157,22 +1170,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -1229,165 +1242,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-bindgen"
@@ -1476,3 +1336,9 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "spyrrow"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "jagua-rs",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyrrow"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyrrow"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ def run():
 thread = threading.Thread(target=run)
 thread.start()
 while thread.is_alive():
-    for report_type, strip_width, density in queue.drain():
-        print(f"{report_type.phase_name()}: width={strip_width:.1f}, density={density:.1%}")
+    for report_type, solution in queue.drain():
+        print(f"{report_type.phase_name()}: width={solution.width:.1f}, density={solution.density:.1%}")
     thread.join(timeout=0.5)
 
 solution = result[0]
 ```
 
 Each report includes a `ReportType` enum value (`ExplFeas`, `ExplInfeas`, `ExplImproving`,
-`CmprFeas`, `Final`) along with the current strip width and density. Use
-`report_type.phase_name()` for a grouped label ("exploring", "compressing", "final")
-or match on the specific variant for finer control.
+`CmprFeas`, `Final`) along with a full `StripPackingSolution` containing width, density,
+and placed items. Use `report_type.phase_name()` for a grouped label ("exploring",
+"compressing", "final") or match on the specific variant for finer control.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,39 @@ for pi in sol.placed_items:
     print("\n")
 ```
 
+## Progress Monitoring
+
+You can monitor the solver's progress in real time using a `ProgressQueue`.
+Since `solve()` releases the GIL internally, the main thread is free to drain
+the queue while the solver runs:
+
+```python
+import threading
+import spyrrow
+
+# ... set up instance and config ...
+
+queue = spyrrow.ProgressQueue()
+result = [None]
+
+def run():
+    result[0] = instance.solve(config, progress=queue)
+
+thread = threading.Thread(target=run)
+thread.start()
+while thread.is_alive():
+    for report_type, strip_width, density in queue.drain():
+        print(f"{report_type.phase_name()}: width={strip_width:.1f}, density={density:.1%}")
+    thread.join(timeout=0.5)
+
+solution = result[0]
+```
+
+Each report includes a `ReportType` enum value (`ExplFeas`, `ExplInfeas`, `ExplImproving`,
+`CmprFeas`, `Final`) along with the current strip width and density. Use
+`report_type.phase_name()` for a grouped label ("exploring", "compressing", "final")
+or match on the specific variant for finer control.
+
 ## Contributing
 
 Spyrrow is open to contributions.

--- a/spyrrow.pyi
+++ b/spyrrow.pyi
@@ -1,5 +1,5 @@
 import enum
-from typing import TypeAlias, Optional, Sequence
+from typing import TypeAlias, Optional, Sequence, Literal
 from datetime import timedelta
 
 Point: TypeAlias = tuple[float, float]
@@ -85,7 +85,7 @@ class ReportType(enum.IntEnum):
     CmprFeas = 3
     Final = 4
 
-    def phase_name(self) -> str:
+    def phase_name(self) -> Literal["exploring", "compressing", "final"]:
         """Return a human-readable phase name.
 
         Returns:

--- a/spyrrow.pyi
+++ b/spyrrow.pyi
@@ -1,3 +1,4 @@
+import enum
 from typing import TypeAlias, Optional, Sequence
 from datetime import timedelta
 
@@ -67,6 +68,46 @@ class StripPackingSolution:
     width: float
     density: float
     placed_items: list[PlacedItem]
+
+class ReportType(enum.IntEnum):
+    """The type of progress report emitted by the solver.
+
+    Attributes:
+        ExplFeas: Feasible solution found during exploration.
+        ExplInfeas: Infeasible solution during exploration.
+        ExplImproving: Improving solution during exploration (not yet feasible).
+        CmprFeas: Feasible solution found during compression.
+        Final: The final solution.
+    """
+    ExplFeas = 0
+    ExplInfeas = 1
+    ExplImproving = 2
+    CmprFeas = 3
+    Final = 4
+
+    def phase_name(self) -> str:
+        """Return a human-readable phase name.
+
+        Returns:
+            One of "exploring", "compressing", or "final".
+        """
+
+class ProgressQueue:
+    """A thread-safe queue that collects progress reports from the solver.
+
+    Create one before calling `solve()` and pass it as the `progress` argument.
+    While the solver runs (in a background thread), call `drain()` to retrieve
+    any new reports.
+    """
+
+    def __init__(self) -> None: ...
+
+    def drain(self) -> list[tuple[ReportType, float, float]]:
+        """Drain all pending progress reports from the queue.
+
+        Returns:
+            A list of (report_type, strip_width, density) tuples.
+        """
 
 class StripPackingConfig:
     early_termination: bool
@@ -141,12 +182,15 @@ class StripPackingInstance:
     def to_json_str(self) -> str:
         """Return a string of the JSON representation of the object"""
 
-    def solve(self, config: StripPackingConfig) -> StripPackingSolution:
+    def solve(self, config: StripPackingConfig, progress: Optional[ProgressQueue] = None) -> StripPackingSolution:
         """
         The method to solve the instance.
 
         Args:
             config (StripPackingConfig): The configuration object to control how the instance is solved.
+            progress (ProgressQueue, optional): If provided, progress reports are pushed to this
+              queue during optimization. Use `queue.drain()` from another thread to monitor progress.
+              Defaults to None.
 
         Returns:
             a StripPackingSolution

--- a/spyrrow.pyi
+++ b/spyrrow.pyi
@@ -102,11 +102,11 @@ class ProgressQueue:
 
     def __init__(self) -> None: ...
 
-    def drain(self) -> list[tuple[ReportType, float, float]]:
+    def drain(self) -> list[tuple[ReportType, StripPackingSolution]]:
         """Drain all pending progress reports from the queue.
 
         Returns:
-            A list of (report_type, strip_width, density) tuples.
+            A list of (report_type, solution) tuples.
         """
 
 class StripPackingConfig:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl ReportTypePy {
     /// Return a human-readable phase name.
     ///
     /// Returns:
-    ///     str: One of "exploring", "compressing", or "final".
+    ///     Literal["exploring", "compressing", "final"]: string representing the phase
     ///
     fn phase_name(&self) -> &'static str {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,8 +195,7 @@ impl From<ReportType> for ReportTypePy {
 
 struct ProgressReport {
     report_type: ReportTypePy,
-    strip_width: f32,
-    density: f32,
+    solution: StripPackingSolutionPy,
 }
 
 #[pyclass(name = "ProgressQueue")]
@@ -211,8 +210,8 @@ struct ProgressReport {
 ///
 ///     queue = spyrrow.ProgressQueue()
 ///     # run solve in a thread, passing progress=queue
-///     for report_type, strip_width, density in queue.drain():
-///         print(f"{report_type.phase_name()}: width={strip_width:.1f}, density={density:.1%}")
+///     for report_type, solution in queue.drain():
+///         print(f"{report_type.phase_name()}: width={solution.width:.1f}, density={solution.density:.1%}")
 ///
 struct ProgressQueuePy {
     inner: Arc<Mutex<VecDeque<ProgressReport>>>,
@@ -230,29 +229,42 @@ impl ProgressQueuePy {
     /// Drain all pending progress reports from the queue.
     ///
     /// Returns:
-    ///     list[tuple[ReportType, float, float]]: A list of (report_type, strip_width, density) tuples.
+    ///     list[tuple[ReportType, StripPackingSolution]]: A list of (report_type, solution) tuples.
     ///
-    fn drain(&self) -> Vec<(ReportTypePy, f32, f32)> {
+    fn drain(&self) -> Vec<(ReportTypePy, StripPackingSolutionPy)> {
         let mut queue = self.inner.lock().unwrap();
-        queue.drain(..).map(|r| (r.report_type, r.strip_width, r.density)).collect()
+        queue.drain(..).map(|r| (r.report_type, r.solution)).collect()
     }
 }
 
 // Implements SolutionListener to push progress reports onto a shared queue.
 struct ProgressListener {
     queue: Arc<Mutex<VecDeque<ProgressReport>>>,
+    item_ids: Vec<String>,
 }
 
 impl SolutionListener for ProgressListener {
     fn report(&mut self, report: ReportType, solution: &SPSolution, instance: &SPInstance) {
-        // Export the solution to get strip_width and density.
-        // This is acceptable because reports are infrequent (only on improving solutions).
+        // Export is acceptable because reports are infrequent (only on improving solutions).
         let exported = jagua_rs::probs::spp::io::export(instance, solution, *EPOCH);
+        let placed_items: Vec<PlacedItemPy> = exported
+            .layout
+            .placed_items
+            .into_iter()
+            .map(|jpi| PlacedItemPy {
+                id: self.item_ids[jpi.item_id as usize].clone(),
+                rotation: jpi.transformation.rotation.to_degrees(),
+                translation: jpi.transformation.translation,
+            })
+            .collect();
         let mut queue = self.queue.lock().unwrap();
         queue.push_back(ProgressReport {
             report_type: ReportTypePy::from(report),
-            strip_width: exported.strip_width,
-            density: exported.density,
+            solution: StripPackingSolutionPy {
+                width: exported.strip_width,
+                density: exported.density,
+                placed_items,
+            },
         });
     }
 }
@@ -496,7 +508,10 @@ impl StripPackingInstancePy {
         let mut terminator = terminator::PythonTerminator::default();
 
         let mut listener = match progress {
-            Some(pq) => SolListener::Progress(ProgressListener { queue: pq.inner }),
+            Some(pq) => SolListener::Progress(ProgressListener {
+                queue: pq.inner,
+                item_ids: self.items.iter().map(|i| i.id.clone()).collect(),
+            }),
             None => SolListener::Dummy(DummySolListener {}),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use jagua_rs::io::ext_repr::{ExtItem as BaseItem, ExtSPolygon, ExtShape};
 use jagua_rs::io::import::Importer;
+use jagua_rs::probs::spp::entities::{SPInstance, SPSolution};
 use jagua_rs::probs::spp::io::ext_repr::{ExtItem, ExtSPInstance};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -10,9 +11,10 @@ use sparrow::EPOCH;
 use sparrow::config::{DEFAULT_SPARROW_CONFIG, ShrinkDecayStrategy};
 use sparrow::consts::{DEFAULT_FAIL_DECAY_RATIO_CMPR, DEFAULT_MAX_CONSEQ_FAILS_EXPL};
 use sparrow::optimizer::optimize;
-use sparrow::util::listener::DummySolListener;
-use std::collections::HashSet;
+use sparrow::util::listener::{DummySolListener, ReportType, SolutionListener};
+use std::collections::{HashSet, VecDeque};
 use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 mod terminator;
@@ -137,6 +139,136 @@ impl StripPackingSolutionPy {
 
     fn __deepcopy__(&self, _memo: Py<PyAny>) -> Self {
         self.clone()
+    }
+}
+
+#[pyclass(name = "ReportType", eq, eq_int)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// The type of progress report emitted by the solver.
+///
+/// Variants:
+///     ExplFeas: Feasible solution found during exploration.
+///     ExplInfeas: Infeasible solution during exploration.
+///     ExplImproving: Improving solution during exploration (not yet feasible).
+///     CmprFeas: Feasible solution found during compression.
+///     Final: The final solution.
+///
+enum ReportTypePy {
+    ExplFeas = 0,
+    ExplInfeas = 1,
+    ExplImproving = 2,
+    CmprFeas = 3,
+    Final = 4,
+}
+
+#[pymethods]
+impl ReportTypePy {
+    /// Return a human-readable phase name.
+    ///
+    /// Returns:
+    ///     str: One of "exploring", "compressing", or "final".
+    ///
+    fn phase_name(&self) -> &'static str {
+        match self {
+            ReportTypePy::ExplFeas | ReportTypePy::ExplInfeas | ReportTypePy::ExplImproving => "exploring",
+            ReportTypePy::CmprFeas => "compressing",
+            ReportTypePy::Final => "final",
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ReportType.{:?}", self)
+    }
+}
+
+impl From<ReportType> for ReportTypePy {
+    fn from(rt: ReportType) -> Self {
+        match rt {
+            ReportType::ExplFeas => ReportTypePy::ExplFeas,
+            ReportType::ExplInfeas => ReportTypePy::ExplInfeas,
+            ReportType::ExplImproving => ReportTypePy::ExplImproving,
+            ReportType::CmprFeas => ReportTypePy::CmprFeas,
+            ReportType::Final => ReportTypePy::Final,
+        }
+    }
+}
+
+struct ProgressReport {
+    report_type: ReportTypePy,
+    strip_width: f32,
+    density: f32,
+}
+
+#[pyclass(name = "ProgressQueue")]
+#[derive(Clone)]
+/// A thread-safe queue that collects progress reports from the solver.
+///
+/// Create one before calling `solve()` and pass it as the `progress` argument.
+/// While the solver runs (in a background thread), call `drain()` to retrieve
+/// any new reports.
+///
+/// Example::
+///
+///     queue = spyrrow.ProgressQueue()
+///     # run solve in a thread, passing progress=queue
+///     for report_type, strip_width, density in queue.drain():
+///         print(f"{report_type.phase_name()}: width={strip_width:.1f}, density={density:.1%}")
+///
+struct ProgressQueuePy {
+    inner: Arc<Mutex<VecDeque<ProgressReport>>>,
+}
+
+#[pymethods]
+impl ProgressQueuePy {
+    #[new]
+    fn new() -> Self {
+        ProgressQueuePy {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Drain all pending progress reports from the queue.
+    ///
+    /// Returns:
+    ///     list[tuple[ReportType, float, float]]: A list of (report_type, strip_width, density) tuples.
+    ///
+    fn drain(&self) -> Vec<(ReportTypePy, f32, f32)> {
+        let mut queue = self.inner.lock().unwrap();
+        queue.drain(..).map(|r| (r.report_type, r.strip_width, r.density)).collect()
+    }
+}
+
+// Implements SolutionListener to push progress reports onto a shared queue.
+struct ProgressListener {
+    queue: Arc<Mutex<VecDeque<ProgressReport>>>,
+}
+
+impl SolutionListener for ProgressListener {
+    fn report(&mut self, report: ReportType, solution: &SPSolution, instance: &SPInstance) {
+        // Export the solution to get strip_width and density.
+        // This is acceptable because reports are infrequent (only on improving solutions).
+        let exported = jagua_rs::probs::spp::io::export(instance, solution, *EPOCH);
+        let mut queue = self.queue.lock().unwrap();
+        queue.push_back(ProgressReport {
+            report_type: ReportTypePy::from(report),
+            strip_width: exported.strip_width,
+            density: exported.density,
+        });
+    }
+}
+
+// Enum wrapper to avoid duplicating the optimize() call in solve().
+enum SolListener {
+    Dummy(DummySolListener),
+    Progress(ProgressListener),
+}
+
+impl SolutionListener for SolListener {
+    fn report(&mut self, report: ReportType, solution: &SPSolution, instance: &SPInstance) {
+        match self {
+            SolListener::Dummy(d) => d.report(report, solution, instance),
+            SolListener::Progress(p) => p.report(report, solution, instance),
+        }
     }
 }
 
@@ -322,11 +454,15 @@ impl StripPackingInstancePy {
     ///
     /// Args:
     ///     config (StripPackingConfig): The configuration object to control how the instance is solved.
+    ///     progress (ProgressQueue, optional): If provided, progress reports are pushed to this
+    ///       queue during optimization. Use `queue.drain()` from another thread to monitor progress.
+    ///       Defaults to None.
     ///
     /// Returns:
     ///     a StripPackingSolution
     ///
-    fn solve(&self, config: StripPackingConfigPy, py: Python) -> StripPackingSolutionPy {
+    #[pyo3(signature = (config, progress=None))]
+    fn solve(&self, config: StripPackingConfigPy, progress: Option<ProgressQueuePy>, py: Python) -> StripPackingSolutionPy {
         if self.items.is_empty() {
             return StripPackingSolutionPy {
                 width: 0.0,
@@ -359,14 +495,16 @@ impl StripPackingInstancePy {
             .expect("Expected a Strip Packing Problem Instance");
         let mut terminator = terminator::PythonTerminator::default();
 
-        // The Python code is not concerned with intermediary solution for now
-        let mut dummy_exporter = DummySolListener {};
+        let mut listener = match progress {
+            Some(pq) => SolListener::Progress(ProgressListener { queue: pq.inner }),
+            None => SolListener::Dummy(DummySolListener {}),
+        };
 
         py.detach(move || {
             let solution = optimize(
                 instance.clone(),
                 rng,
-                &mut dummy_exporter,
+                &mut listener,
                 &mut terminator,
                 &rs_config.expl_cfg,
                 &rs_config.cmpr_cfg,
@@ -403,6 +541,8 @@ fn spyrrow(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<StripPackingInstancePy>()?;
     m.add_class::<StripPackingConfigPy>()?;
     m.add_class::<StripPackingSolutionPy>()?;
+    m.add_class::<ReportTypePy>()?;
+    m.add_class::<ProgressQueuePy>()?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl SolutionListener for ProgressListener {
             .into_iter()
             .map(|jpi| PlacedItemPy {
                 id: self.item_ids[jpi.item_id as usize].clone(),
-                rotation: jpi.transformation.rotation.to_degrees(),
+                rotation: jpi.transformation.rotation,
                 translation: jpi.transformation.translation,
             })
             .collect();
@@ -534,7 +534,7 @@ impl StripPackingInstancePy {
                 .into_iter()
                 .map(|jpi| PlacedItemPy {
                     id: self.items[jpi.item_id as usize].id.clone(),
-                    rotation: jpi.transformation.rotation, // This is in degrees already know
+                    rotation: jpi.transformation.rotation, // This is in degrees already now
                     translation: jpi.transformation.translation,
                 })
                 .collect();


### PR DESCRIPTION
Exposes sparrow's existing SolutionListener mechanism to Python via a new `ProgressQueue` class and `ReportType` enum.

When passed to `solve()`, the queue collects `(ReportType, strip_width, density)` tuples that can be drained from another thread for progress bars, logging, or monitoring. `ReportType` mirrors sparrow's 5 report variants (`ExplFeas`, `ExplInfeas`, `ExplImproving`, `CmprFeas`, `Final`), with a `phase_name()` convenience method for grouped labels.

`solve()` works exactly as before when no queue is passed.

```python
queue = spyrrow.ProgressQueue()
result = [None]

def run():
    result[0] = instance.solve(config, progress=queue)

thread = threading.Thread(target=run)
thread.start()
while thread.is_alive():
    for report_type, strip_width, density in queue.drain():
        print(f"{report_type.phase_name()}: width={strip_width:.1f}, density={density:.1%}")
    thread.join(timeout=0.5)

solution = result[0]
```